### PR TITLE
Update Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM python:3.12
 COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
 COPY . .
-ENTRYPOINT ["python", "-m", "src.daemon"]
+ENV PYTHONBUFFERED=1
+ENTRYPOINT ["python", "-m"]


### PR DESCRIPTION
Updates the Dockerfile to specify the entry point as `python -m`. This makes the Dockerfile compatible with the current build args we specified in the infrastructure repo: https://github.com/cowprotocol/infrastructure/blob/f2d440aef6c38729dd2e9983e2e0d48a8720590f/solver-rewards/token-imbalances/index.ts#L52

Also adds `PYTHONBUFFERED=1` to disable buffering of the logs.