### PR TITLE
Edit start block for current accounting period

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -207,7 +207,8 @@ def process_transactions(chain_name: str) -> None:
         solver_slippage_db_connection,
     ) = initialize_connections()
     rt = RawTokenImbalances(web3, chain_name)
-    start_block = get_start_block(web3, chain_name, solver_slippage_db_connection)
+    # start_block = get_start_block(web3, chain_name, solver_slippage_db_connection)
+    start_block = 20417850
     previous_block = start_block
     unprocessed_txs: List[Tuple[str, int, int]] = []
 

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -208,7 +208,7 @@ def process_transactions(chain_name: str) -> None:
     ) = initialize_connections()
     rt = RawTokenImbalances(web3, chain_name)
     # start_block = get_start_block(web3, chain_name, solver_slippage_db_connection)
-    start_block = 20417850
+    start_block = 20419429
     previous_block = start_block
     unprocessed_txs: List[Tuple[str, int, int]] = []
 


### PR DESCRIPTION
This PR has a one-line edit:

The start_block in process_transactions() is hardcoded for the current accounting period.