### PR TITLE
Fee Withdrawal check (pytest), Updated Readme, .env.sample edit

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,5 +15,5 @@ CHAIN_SLEEP_TIME=
 # add chain name, e.g. CHAIN_NAME=Ethereum
 CHAIN_NAME=
 
-# optional
-INFURA_KEY=
+# OPTIONAL: when running imbalances_script to test for a single tx hash, must provide below variables
+ETHEREUM_NODE_URL=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # token-imbalances
 
 This script is to calculate the raw token imbalances before and after a settlement.
+The raw token imbalances are stored in the raw_token_imbalances table.
+Additionally, coingecko prices for fetchable token addresses at the time of transaction are stored in the coingecko_prices table. These tables are a part of the Solver Slippage Database.
+These prices can be used to convert raw imbalances to ETH.
 
 
 **Install requirements from root directory:**
@@ -10,8 +13,16 @@ pip install -r requirements.txt
 
 **Environment Variables**: Make sure the `.env` file is correctly set up locally. You can use the `.env.sample` file as reference.
 
-**From the root directory, run:**
+**To fetch imbalances for a single transaction hash, run:**
+```bash
+python -m src.imbalances_script
+```
+
+**To run a daemon for checking imbalances, run the following from the root directory:**
 
 ```bash
 python -m src.daemon
 ```
+
+**To run the basic test in the `tests/` folder:**
+ using pytest, simply run the command: `pytest` 

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -7,6 +7,7 @@ from src.helper_functions import get_web3_instance
 
 load_dotenv()
 
+
 @pytest.mark.parametrize(
     "tx_hash, expected_imbalances",
     [
@@ -42,7 +43,7 @@ load_dotenv()
                 "0x853d955aCEf822Db058eb8505911ED77F175b99e": 7064735278981936006,
                 "0x3472A5A71965499acd81997a54BBA8D852C6E53d": 2852137014171065178,
                 "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": 4722264073109523,
-                "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29": 10246847087992681796
+                "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29": 10246847087992681796,
             },
         ),
     ],

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -1,7 +1,11 @@
 """ Runs a basic test for raw imbalance calculation edge-cases. """
+import os
+from dotenv import load_dotenv
 import pytest
 from src.imbalances_script import RawTokenImbalances
+from src.helper_functions import get_web3_instance
 
+load_dotenv()
 
 @pytest.mark.parametrize(
     "tx_hash, expected_imbalances",
@@ -31,13 +35,24 @@ from src.imbalances_script import RawTokenImbalances
                 "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": 64641750602289665,
             },
         ),
+        # Fee Withdrawal Transaction
+        (
+            "0x6c83fe83684b6f8ad0f8141aa4c359ad359c09b14c8ff9b9b2a0a80228ed10de",
+            {
+                "0x853d955aCEf822Db058eb8505911ED77F175b99e": 7064735278981936006,
+                "0x3472A5A71965499acd81997a54BBA8D852C6E53d": 2852137014171065178,
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": 4722264073109523,
+                "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29": 10246847087992681796
+            },
+        ),
     ],
 )
 def test_imbalances(tx_hash, expected_imbalances):
     """
     Asserts imbalances match for main script with test values provided.
     """
-    rt = RawTokenImbalances()
-    imbalances, _ = rt.compute_imbalances(tx_hash)
+    chain_name = os.getenv("CHAIN_NAME")
+    rt = RawTokenImbalances(get_web3_instance(), chain_name)
+    imbalances = rt.compute_imbalances(tx_hash)
     for token_address, expected_imbalance in expected_imbalances.items():
         assert imbalances.get(token_address) == expected_imbalance


### PR DESCRIPTION
Updated:

1. basic_test.py to include the fee withdrawal transaction as a test with expected values provided.
2. Updated Readme that provides more high level relevance to what we currently have in this repo.
3. .env.sample edit to make it clear that the last URL (ETHEREUM_NODE_URL) only needs to be provided when running the imbalances_script.py solely, i.e. when testing for a single tx hash.