### PR TITLE
Coingecko Edits (from discussion)

### DIFF
--- a/src/coingecko_pricing.py
+++ b/src/coingecko_pricing.py
@@ -54,7 +54,7 @@ def fetch_api_price(
         return None
 
 
-def price_retrievable(web3: Web3, block_start_timestamp: int) -> bool:
+def price_not_retrievable(web3: Web3, block_start_timestamp: int) -> bool:
     """
     This function checks if the time elapsed between the latest block and block being processed
     is less than 2 days, which is coingecko's time frame for fetching 5-minutely data.
@@ -74,7 +74,7 @@ def get_price(web3: Web3, block_number: int, token_address: str, tx_hash: str):
     """
 
     block_start_timestamp = web3.eth.get_block(block_number)["timestamp"]
-    if price_retrievable(web3, block_start_timestamp):
+    if price_not_retrievable(web3, block_start_timestamp):
         return None
 
     # Coingecko doesn't store ETH address, which occurs commonly in imbalances.

--- a/src/coingecko_pricing.py
+++ b/src/coingecko_pricing.py
@@ -64,8 +64,8 @@ def price_retrievable(web3: Web3, block_start_timestamp: int) -> bool:
     newest_block_timestamp = web3.eth.get_block(get_finalized_block_number(web3))[
         "timestamp"
     ]
-    if (newest_block_timestamp - block_start_timestamp) > COINGECKO_TIME_LIMIT:
-        return True
+    return (newest_block_timestamp - block_start_timestamp) > COINGECKO_TIME_LIMIT
+
 
 
 def get_price(web3: Web3, block_number: int, token_address: str, tx_hash: str):

--- a/src/coingecko_pricing.py
+++ b/src/coingecko_pricing.py
@@ -67,7 +67,6 @@ def price_retrievable(web3: Web3, block_start_timestamp: int) -> bool:
     return (newest_block_timestamp - block_start_timestamp) > COINGECKO_TIME_LIMIT
 
 
-
 def get_price(web3: Web3, block_number: int, token_address: str, tx_hash: str):
     """
     Function returns coingecko price for a token address,

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -209,9 +209,6 @@ def process_transactions(chain_name: str) -> None:
     ) = initialize_connections()
     rt = RawTokenImbalances(web3, chain_name)
     start_block = get_start_block(web3, chain_name, solver_slippage_db_connection)
-    ## this is just saying that the start block should be hardcoded in case the script restarts a few hours after that specific block
-    if start_block - 12000 < 20420000:
-        start_block = 20420000
     previous_block = start_block
     unprocessed_txs: List[Tuple[str, int, int]] = []
 


### PR DESCRIPTION
This is a small PR is to include the following changes:

1. WETH price is fixed to equal 1 ETH. So when calling the coingecko price fetching function, token addresses for ETH and now WETH return 1.0, which is the price of each of these tokens in ETH.

2. price_retrievable() checks time elapsed between the latest block and block being processed to make sure it's less than 2 days (currently set to 45 hours), which is coingecko's time frame for fetching 5-minutely data.