### PR TITLE
Catch dune error

### DIFF
--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -55,7 +55,7 @@ class DunePriceProvider(AbstractPriceProvider):
             try:
                 result = dune.run_query(query=query)  # type: ignore[attr-defined]
             except DuneError as e:
-                logger.warning(f"Unable to run query, Dune returned with error {e}")
+                self.logger.warning(f"Unable to run query, Dune returned with error {e}")
                 return None
             if result.result.rows:
                 row = result.result.rows[0]

--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -3,6 +3,7 @@ from src.price_providers.pricing_model import AbstractPriceProvider
 from dune_client.types import QueryParameter
 from dune_client.client import DuneClient
 from dune_client.query import QueryBase
+from dune_client.modesl import DuneError
 from src.helpers.config import get_web3_instance, get_logger
 from src.helpers.helper_functions import extract_params
 from src.constants import DUNE_PRICE_QUERY_ID, DUNE_QUERY_BUFFER_TIME
@@ -51,7 +52,11 @@ class DunePriceProvider(AbstractPriceProvider):
                     ),
                 ],
             )
-            result = dune.run_query(query=query)  # type: ignore[attr-defined]
+            try:
+                result = dune.run_query(query=query)  # type: ignore[attr-defined]
+            except DuneError as e:
+                logger.error(f"Unable to run query, dune returned with error {e}")
+                return None
             if result.result.rows:
                 row = result.result.rows[0]
                 price = row.get("price")

--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -3,7 +3,7 @@ from src.price_providers.pricing_model import AbstractPriceProvider
 from dune_client.types import QueryParameter
 from dune_client.client import DuneClient
 from dune_client.query import QueryBase
-from dune_client.modesl import DuneError
+from dune_client.models import DuneError
 from src.helpers.config import get_web3_instance, get_logger
 from src.helpers.helper_functions import extract_params
 from src.constants import DUNE_PRICE_QUERY_ID, DUNE_QUERY_BUFFER_TIME

--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -55,7 +55,9 @@ class DunePriceProvider(AbstractPriceProvider):
             try:
                 result = dune.run_query(query=query)  # type: ignore[attr-defined]
             except DuneError as e:
-                self.logger.warning(f"Unable to run query, Dune returned with error {e}")
+                self.logger.warning(
+                    f"Unable to run query, Dune returned with error {e}"
+                )
                 return None
             if result.result.rows:
                 row = result.result.rows[0]

--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -55,7 +55,7 @@ class DunePriceProvider(AbstractPriceProvider):
             try:
                 result = dune.run_query(query=query)  # type: ignore[attr-defined]
             except DuneError as e:
-                logger.error(f"Unable to run query, dune returned with error {e}")
+                logger.warning(f"Unable to run query, Dune returned with error {e}")
                 return None
             if result.result.rows:
                 row = result.result.rows[0]


### PR DESCRIPTION
This PR catches the [DuneError](https://github.com/duneanalytics/dune-client/blob/775549b7fa9cc4680f78b88d29daddae955b0000/dune_client/models.py#L29) returned by the `dune_client` when it is unable to execute a query. 

Catching and logging this prevents us from receiving alerts about this while still making it easy to find these errors in the logs.