### PR TITLE
fix tx hash error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-web3>=6.0.0
+web3==7.0.0
 pandas==2.2.1
 SQLAlchemy==2.0.28
 psycopg2==2.9.9

--- a/src/helpers/blockchain_data.py
+++ b/src/helpers/blockchain_data.py
@@ -46,7 +46,7 @@ class BlockchainData:
             block = self.web3.eth.get_block(block_number, full_transactions=True)
             for tx in block.transactions:  # type: ignore[attr-defined]
                 if tx.to and tx.to.lower() == SETTLEMENT_CONTRACT_ADDRESS.lower():
-                    tx_hashes_blocks.append((tx.hash.hex(), block_number))
+                    tx_hashes_blocks.append((tx.hash.to_0x_hex(), block_number))
         return tx_hashes_blocks
 
     def get_auction_id(self, tx_hash: str) -> int:


### PR DESCRIPTION
This PR fixes why the leading 2 characters were missing in the tx_hash logs and db entries.
hexBytes v0.3.0 -> v1.2.1, which is a dependency of the new web3py v7.