### PR TITLE
Slightly clearer exception handling for prices

### DIFF
--- a/src/price_providers/coingecko_pricing.py
+++ b/src/price_providers/coingecko_pricing.py
@@ -153,10 +153,10 @@ class CoingeckoPriceProvider(AbstractPriceProvider):
                 token_id, block_start_timestamp, block_end_timestamp
             )
             if api_price is None:
-                logger.warning(f"API returned None for token ID: {token_id}")
+                logger.warning(f"Coingecko API returned None for token ID: {token_id}")
                 return None
         except requests.RequestException as e:
-            logger.error(f"Error fetching price from API: {e}")
+            logger.error(f"Error fetching price from Coingecko API: {e}")
             return None
 
         return api_price

--- a/src/price_providers/dune_pricing.py
+++ b/src/price_providers/dune_pricing.py
@@ -70,6 +70,7 @@ class DunePriceProvider(AbstractPriceProvider):
                 if price is not None:
                     return price
             # No valid price found
+            self.logger.warning("Price not found on Dune.")
             return None
         except KeyError as e:
             self.logger.error(f"Key error occurred: {e}")

--- a/src/price_providers/endpoint_auction_pricing.py
+++ b/src/price_providers/endpoint_auction_pricing.py
@@ -43,8 +43,11 @@ class AuctionPriceProvider(AbstractPriceProvider):
                 return price_in_eth
 
             except requests.exceptions.HTTPError as err:
-                if err.response.status_code == 404:
-                    pass
+                # Continue to check if tx present on barn.
+                if err.response.status_code == 404 and environment == "prod":
+                    continue
+                # Error logged if tx not found on barn either.
+                logger.error(f"Error: {err}")
             except requests.exceptions.RequestException as req_err:
                 logger.error(f"Error occurred during request: {req_err}")
             except KeyError as key_err:

--- a/src/price_providers/moralis_pricing.py
+++ b/src/price_providers/moralis_pricing.py
@@ -53,6 +53,6 @@ class MoralisPriceProvider(AbstractPriceProvider):
             self.logger.warning(f"Error: {e}")
         except Exception as e:
             self.logger.warning(
-                f"Error: {e}, Likely the token: {token_address} was not found or API limit reached."
+                f"Price retrieval for token: {token_address} returned: {e}"
             )
         return None


### PR DESCRIPTION
As the title suggests, minor changes to specify which APIs haven't been able to provide prices, and due to what reason.