### PR TITLE
Fix SQL error in fees

### DIFF
--- a/src/sql/delete_entries_max_block.sql
+++ b/src/sql/delete_entries_max_block.sql
@@ -8,4 +8,7 @@ DELETE FROM slippage_prices
 WHERE chain_name = :chain_name
 AND block_number >= :block_number;
 
+DELETE FROM fees
+WHERE chain_name = :chain_name
+AND block_number >= :block_number;
 COMMIT;

--- a/src/sql/select_max_block.sql
+++ b/src/sql/select_max_block.sql
@@ -8,4 +8,8 @@ FROM (
     SELECT MAX(block_number) AS max_block_number 
     FROM slippage_prices
     WHERE chain_name = :chain_name
+    UNION ALL
+    SELECT MAX(block_number) AS max_block_number 
+    FROM fees
+    WHERE chain_name = :chain_name
 ) AS max_blocks;


### PR DESCRIPTION
When we merge, entries for the last processed block is deleted and becomes the new start block to avoid missing out on any settlements.
Before this PR, after any merge to main, entries are deleted from `raw_token_imbalances` and `slippage_prices` tables, but not `fees`. This results in an attempted re-write to fees and thus the SQL error in opensearch that the key already exists.

This PR modifies our queries to delete the entries from `fees` too.