### PR TITLE
Fixed inconsistency in table schema

### DIFF
--- a/src/helpers/database.py
+++ b/src/helpers/database.py
@@ -37,16 +37,6 @@ class Database:
                 connection.rollback()
                 raise
 
-    def record_exists(self, tx_hash: bytes, token_address: bytes) -> bool:
-        """
-        Function checks if an entry of (tx_hash, token) already exists in the token imbalances table.
-        """
-        query = read_sql_file("src/sql/select_record_exists.sql")
-        result = self.execute_query(
-            query, {"tx_hash": tx_hash, "token_address": token_address}
-        )
-        return result.fetchone() is not None
-
     def write_token_imbalances(
         self,
         tx_hash: str,
@@ -59,19 +49,18 @@ class Database:
         tx_hash_bytes = bytes.fromhex(tx_hash[2:])
         token_address_bytes = bytes.fromhex(token_address[2:])
 
-        if not self.record_exists(tx_hash_bytes, token_address_bytes):
-            query = read_sql_file("src/sql/insert_raw_token_imbalances.sql")
-            self.execute_and_commit(
-                query,
-                {
-                    "auction_id": auction_id,
-                    "chain_name": self.chain_name,
-                    "block_number": block_number,
-                    "tx_hash": tx_hash_bytes,
-                    "token_address": token_address_bytes,
-                    "imbalance": imbalance,
-                },
-            )
+        query = read_sql_file("src/sql/insert_raw_token_imbalances.sql")
+        self.execute_and_commit(
+            query,
+            {
+                "auction_id": auction_id,
+                "chain_name": self.chain_name,
+                "block_number": block_number,
+                "tx_hash": tx_hash_bytes,
+                "token_address": token_address_bytes,
+                "imbalance": imbalance,
+            },
+        )
 
     def write_prices(
         self,

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -7,7 +7,8 @@ CREATE TABLE raw_token_imbalances (
     block_number BIGINT NOT NULL,
     tx_hash BYTEA NOT NULL,
     token_address BYTEA NOT NULL,
-    imbalance NUMERIC(78,0)
+    imbalance NUMERIC(78,0),
+    PRIMARY KEY (tx_hash, token_address)
 );
 
 -- Table: slippage_prices (for storing per unit token prices in ETH)

--- a/src/sql/select_record_exists.sql
+++ b/src/sql/select_record_exists.sql
@@ -1,3 +1,0 @@
-SELECT 1 FROM raw_token_imbalances
-WHERE tx_hash = :tx_hash 
-AND token_address = :token_address;


### PR DESCRIPTION
There was previously no primary key in the `raw_token_imbalances` table, and instead we had a function called record_exists that would check if (tx_hash, token_address) exists in the table.

Nothing wrong with it, but better to have consistency since the `slippage_prices` and `fees` tables use a primary key, so didn't make sense to have a function just for `raw_token_imbalances`.
 
The primary key has already been added to `raw_token_imbalances`.