### PR TITLE
Fix parameter name passed to sql query

### DIFF
--- a/src/helpers/database.py
+++ b/src/helpers/database.py
@@ -121,6 +121,6 @@ class Database:
                 "token_address": token_address_bytes,
                 "fee_amount": fee_amount,
                 "fee_type": fee_type,
-                "recipient": final_recipient,
+                "fee_recipient": final_recipient,
             },
         )


### PR DESCRIPTION
Turns out there was a mismatch in the name of the parameter that was passed on to an sql query, that was not properly addressed in PR #53. This PR should do it