### PR TITLE
Fix metadata issue

### DIFF
--- a/src/fees/compute_fees.py
+++ b/src/fees/compute_fees.py
@@ -372,12 +372,13 @@ class OrderbookFetcher:
             fee_policies = self.parse_fee_policies(trade_data["feePolicies"])
 
             app_data = json.loads(order_data["fullAppData"])
-            if "partnerFee" in app_data["metadata"].keys():
-                partner_fee_recipient = Web3.to_checksum_address(
-                    HexBytes(app_data["metadata"]["partnerFee"]["recipient"])
-                )
-            else:
-                partner_fee_recipient = NULL_ADDRESS
+            partner_fee_recipient = NULL_ADDRESS
+            if "metadata" in app_data.keys():
+                if "partnerFee" in app_data["metadata"].keys():
+                    partner_fee_recipient = Web3.to_checksum_address(
+                        HexBytes(app_data["metadata"]["partnerFee"]["recipient"])
+                    )
+
 
             trade = Trade(
                 order_uid=uid,

--- a/src/fees/compute_fees.py
+++ b/src/fees/compute_fees.py
@@ -379,7 +379,6 @@ class OrderbookFetcher:
                         HexBytes(app_data["metadata"]["partnerFee"]["recipient"])
                     )
 
-
             trade = Trade(
                 order_uid=uid,
                 sell_amount=executed_sell_amount,


### PR DESCRIPTION
The code assumes that there is always a "metadata" key in the appdata dictionary. This is not always the case; see e.g, [this](https://explorer.cow.fi/orders/0xc5daf179a664d9032fe9e0c54303cfa51fa838bb508a6e44f0eebe7c7e711521b83899982599174594d2c1abbb3df3325df9f94b66fffa65?tab=overview) order. In such cases, the script produces an error

```
    if "partnerFee" in app_data["metadata"].keys():
                       ~~~~~~~~^^^^^^^^^^^^
KeyError: 'metadata'
```
This PR addresses this.