### PR TITLE
Disable fee calculations

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -13,7 +13,7 @@ def main() -> None:
         return
 
     process_imbalances = True
-    process_fees = True
+    process_fees = False
     process_prices = True
 
     web3, db_engine = initialize_connections()


### PR DESCRIPTION
This PR effectively disables all fee calculations as the backend is pushing protocol/partner fee calculations to prod tomorrow.

As that part of the script has generated a lot of errors due to the various api calls it is doing, this PR proposes to disable it until further notice.