### PR TITLE
Initialize empty price feed object on other chains

### DIFF
--- a/src/price_providers/price_feed.py
+++ b/src/price_providers/price_feed.py
@@ -8,12 +8,15 @@ from src.helpers.config import logger
 class PriceFeed:
     """Class encapsulating the different price providers."""
 
-    def __init__(self):
-        self.providers = [
-            CoingeckoPriceProvider(),
-            MoralisPriceProvider(),
-            AuctionPriceProvider(),
-        ]
+    def __init__(self, activate: bool):
+        if activate:
+            self.providers = [
+                CoingeckoPriceProvider(),
+                MoralisPriceProvider(),
+                AuctionPriceProvider(),
+            ]
+        else:
+            self.providers = []
 
     def get_price(self, price_params: dict) -> tuple[float, str] | None:
         """Function iterates over list of price provider objects and attempts to get a price."""

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -30,7 +30,7 @@ class TransactionProcessor:
         self.process_prices = process_prices
 
         self.imbalances = RawTokenImbalances(self.blockchain_data.web3, self.chain_name)
-        self.price_providers = PriceFeed(process_prices)
+        self.price_providers = PriceFeed(activate=process_prices)
         self.log_message: list[str] = []
 
     def get_start_block(self) -> int:

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -30,7 +30,7 @@ class TransactionProcessor:
         self.process_prices = process_prices
 
         self.imbalances = RawTokenImbalances(self.blockchain_data.web3, self.chain_name)
-        self.price_providers = PriceFeed()
+        self.price_providers = PriceFeed(process_prices)
         self.log_message: list[str] = []
 
     def get_start_block(self) -> int:


### PR DESCRIPTION
Currently, the script crashes on non-mainnet chains as we don't have available price feeds. This PR fixes the initialization of the price feed object in cases where we don't want to compute prices