### PR TITLE
Remove conservative deletes on restarts

### DIFF
--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -47,13 +47,17 @@ class TransactionProcessor:
             )
             row = result.fetchone()
             max_block = row[0] if row is not None else None
+            blockchain_latest_block = self.blockchain_data.get_latest_block()
 
             # If no entries present, fallback to get_latest_block()
             if max_block is None:
-                return self.blockchain_data.get_latest_block()
+                return blockchain_latest_block
 
             logger.info("Fetched max block number from database: %d", max_block)
-            return max_block + 1
+            if max_block > blockchain_latest_block - 7200:
+                return max_block + 1
+            else:
+                return blockchain_latest_block
         except Exception as e:
             logger.error("Error fetching start block from database: %s", e)
             raise

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -37,6 +37,9 @@ class TransactionProcessor:
         """
         Retrieve the most recent block X already present in raw_token_imbalances table,
         and return block X+1 as start_block.
+        If block X is from more than 1 day ago, a recent finalized block is returned.
+        TODO: Remove that rule before moving to production.
+
         If no entries are present, fallback to get_finalized_block_number().
         """
         try:
@@ -57,6 +60,7 @@ class TransactionProcessor:
             if max_block > blockchain_latest_block - 7200:
                 return max_block + 1
             else:
+                #  TODO: Remove this rule before moving to production.
                 return blockchain_latest_block
         except Exception as e:
             logger.error("Error fetching start block from database: %s", e)

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -35,8 +35,8 @@ class TransactionProcessor:
 
     def get_start_block(self) -> int:
         """
-        Retrieve the most recent block already present in raw_token_imbalances table,
-        delete entries for that block, and return this block number as start_block.
+        Retrieve the most recent block X already present in raw_token_imbalances table,
+        and return block X+1 as start_block.
         If no entries are present, fallback to get_finalized_block_number().
         """
         try:
@@ -53,13 +53,7 @@ class TransactionProcessor:
                 return self.blockchain_data.get_latest_block()
 
             logger.info("Fetched max block number from database: %d", max_block)
-
-            # Delete entries for the max block from the table
-            delete_sql = read_sql_file("src/sql/delete_entries_max_block.sql")
-            self.db.execute_and_commit(
-                delete_sql, {"chain_name": self.chain_name, "block_number": max_block}
-            )
-            return max_block
+            return max_block + 1
         except Exception as e:
             logger.error("Error fetching start block from database: %s", e)
             raise


### PR DESCRIPTION
When the daemon restarts, it acts conservatively and deletes the latest entry found in the db, in order to recheck that block. This aims to catch cases where the daemon crashed in the middle of writing in the db. Given that current error handling is not great, this has resulted in cases where the daemon starts crashes and actually starts deleting entries, one by one, ending up in deleting days of data.

This PR proposes to remove this deletion step until we make the daemon very robust, and until we are convinced it is needed. Moreover, it forces the daemon to not look too far back in the past (at most 1 day), and if latest data is older than 1 day, then it ignores the gaps and continues from latest block. In practice, we should not expect downtimes of more than 1 day, so this should be fine in most cases.