### PR TITLE
Use multiple price feeds always

### DIFF
--- a/src/price_providers/price_feed.py
+++ b/src/price_providers/price_feed.py
@@ -1,4 +1,3 @@
-from typing import List
 from src.price_providers.coingecko_pricing import CoingeckoPriceProvider
 from src.price_providers.dune_pricing import DunePriceProvider
 from src.price_providers.moralis_pricing import MoralisPriceProvider
@@ -19,7 +18,7 @@ class PriceFeed:
         else:
             self.providers = []
 
-    def get_price(self, price_params: dict) -> List[tuple[float, str]]:
+    def get_price(self, price_params: dict) -> list[tuple[float, str]]:
         """Function iterates over list of price provider objects and attempts to get a price."""
         prices = []
         for provider in self.providers:

--- a/src/price_providers/price_feed.py
+++ b/src/price_providers/price_feed.py
@@ -1,3 +1,4 @@
+from typing import List
 from src.price_providers.coingecko_pricing import CoingeckoPriceProvider
 from src.price_providers.dune_pricing import DunePriceProvider
 from src.price_providers.moralis_pricing import MoralisPriceProvider
@@ -18,13 +19,14 @@ class PriceFeed:
         else:
             self.providers = []
 
-    def get_price(self, price_params: dict) -> tuple[float, str] | None:
+    def get_price(self, price_params: dict) -> List[tuple[float, str]]:
         """Function iterates over list of price provider objects and attempts to get a price."""
+        prices = []
         for provider in self.providers:
             try:
                 price = provider.get_price(price_params)
                 if price is not None:
-                    return price, provider.name
+                    prices.append((price, provider.name))
             except Exception as e:
                 logger.error(f"Error getting price from provider {provider.name}: {e}")
-        return None
+        return prices

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -290,7 +290,7 @@ class TransactionProcessor:
             )
 
     def handle_prices(
-        self, prices: dict[str, tuple[float, str]], tx_hash: str, block_number: int
+        self, prices: dict[str, List[tuple[float, str]]], tx_hash: str, block_number: int
     ) -> None:
         """Function writes prices to table per token."""
         try:

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -1,7 +1,6 @@
 import time
 from hexbytes import HexBytes
 from web3 import Web3
-from typing import List
 from src.helpers.blockchain_data import BlockchainData
 from src.helpers.database import Database
 from src.imbalances_script import RawTokenImbalances
@@ -192,7 +191,7 @@ class TransactionProcessor:
         token_imbalances: dict[str, int],
         block_number: int,
         tx_hash: str,
-    ) -> dict[str, List[tuple[float, str]]]:
+    ) -> dict[str, list[tuple[float, str]]]:
         """Compute prices for tokens with non-null imbalances."""
         prices = {}
         try:
@@ -291,7 +290,7 @@ class TransactionProcessor:
 
     def handle_prices(
         self,
-        prices: dict[str, List[tuple[float, str]]],
+        prices: dict[str, list[tuple[float, str]]],
         tx_hash: str,
         block_number: int,
     ) -> None:

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -201,10 +201,7 @@ class TransactionProcessor:
                     set_params(token_address, block_number, tx_hash)
                 )
                 if price_data:
-                    res = []
-                    for data_point in price_data:
-                        res.append(data_point)
-                    prices[token_address] = res
+                    prices[token_address] = price_data
         except Exception as e:
             logger.error(f"Failed to process prices for transaction {tx_hash}: {e}")
 

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -290,7 +290,10 @@ class TransactionProcessor:
             )
 
     def handle_prices(
-        self, prices: dict[str, List[tuple[float, str]]], tx_hash: str, block_number: int
+        self,
+        prices: dict[str, List[tuple[float, str]]],
+        tx_hash: str,
+        block_number: int,
     ) -> None:
         """Function writes prices to table per token."""
         try:


### PR DESCRIPTION
So far, we have used an ordering of price feeds, in the sense that we query the first API, and if it succeeds, we stop, and only continue with the second price feed if the first one doesn't respond. This PR changes this by forcing the use of all available price feeds/apis always.