### PR TITLE
Fix issue with missing topics

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,3 +25,7 @@ jobs:
           black --check ./
       - name: Type Check (mypy)
         run: mypy src
+      - name: Tests
+        run: pytest tests/e2e/test_blockchain_data.py
+        env:
+          NODE_URL: ${{ secrets.NODE_URL }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,5 +27,3 @@ jobs:
         run: mypy src
       - name: Tests
         run: pytest tests/e2e/test_blockchain_data.py
-        env:
-          NODE_URL: ${{ secrets.NODE_URL }}

--- a/src/helpers/blockchain_data.py
+++ b/src/helpers/blockchain_data.py
@@ -50,6 +50,7 @@ class BlockchainData:
                     if any(
                         log.topics[0].to_0x_hex() == INVALIDATED_ORDER_TOPIC
                         for log in receipt.logs  # type: ignore[attr-defined]
+                        if log.topics  # type: ignore[attr-defined]
                     ):
                         continue
                     # status = 0 indicates a reverted tx, status = 1 is successful tx

--- a/tests/e2e/test_blockchain_data.py
+++ b/tests/e2e/test_blockchain_data.py
@@ -1,11 +1,8 @@
 from os import getenv, environ
 from unittest.mock import patch
 
-from dotenv import load_dotenv
 import pytest
 from web3 import Web3
-
-load_dotenv()
 
 
 @pytest.fixture()
@@ -14,6 +11,7 @@ def set_env_variables(monkeypatch):
     with patch.dict(environ, clear=True):
         envvars = {
             "CHAIN_SLEEP_TIME": "1",
+            "NODE_URL": "https://rpc.mevblocker.io",
         }
         for k, v in envvars.items():
             monkeypatch.setenv(k, v)

--- a/tests/e2e/test_blockchain_data.py
+++ b/tests/e2e/test_blockchain_data.py
@@ -1,13 +1,29 @@
-from os import getenv
+from os import getenv, environ
+from unittest.mock import patch
 
 from dotenv import load_dotenv
+import pytest
 from web3 import Web3
-from src.helpers.blockchain_data import BlockchainData
 
 load_dotenv()
 
 
-def tests_get_tx_hashes_blocks():
+@pytest.fixture()
+def set_env_variables(monkeypatch):
+    """Set `REMOVE_SOLVER_PK` to a string so that blacklisting can be called."""
+    with patch.dict(environ, clear=True):
+        envvars = {
+            "CHAIN_SLEEP_TIME": "1",
+        }
+        for k, v in envvars.items():
+            monkeypatch.setenv(k, v)
+        yield  # This is the magical bit which restore the environment after
+
+
+def tests_get_tx_hashes_blocks(set_env_variables):
+    # import has to happen after patching environment variable
+    from src.helpers.blockchain_data import BlockchainData
+
     web3 = Web3(Web3.HTTPProvider(getenv("NODE_URL")))
     blockchain = BlockchainData(web3)
     start_block = 20892118

--- a/tests/e2e/test_blockchain_data.py
+++ b/tests/e2e/test_blockchain_data.py
@@ -7,7 +7,6 @@ from web3 import Web3
 
 @pytest.fixture()
 def set_env_variables(monkeypatch):
-    """Set `REMOVE_SOLVER_PK` to a string so that blacklisting can be called."""
     with patch.dict(environ, clear=True):
         envvars = {
             "CHAIN_SLEEP_TIME": "1",

--- a/tests/e2e/test_blockchain_data.py
+++ b/tests/e2e/test_blockchain_data.py
@@ -1,0 +1,19 @@
+from os import getenv
+
+from dotenv import load_dotenv
+from web3 import Web3
+from src.helpers.blockchain_data import BlockchainData
+
+load_dotenv()
+
+
+def tests_get_tx_hashes_blocks():
+    web3 = Web3(Web3.HTTPProvider(getenv("NODE_URL")))
+    blockchain = BlockchainData(web3)
+    start_block = 20892118
+    end_block = start_block
+    res = blockchain.get_tx_hashes_blocks(start_block, end_block)
+    assert res[0] == (
+        "0xb75e03b63d4f06c56549effd503e1e37f3ccfc3c00e6985a5aacc9b0534d7c5c",
+        20892118,
+    )


### PR DESCRIPTION
The PR closes #68.

It also adds a test for the block which broke the script.

~At the moment the test should fail due to a missing node url secret.~
Tests are using a public MEV blocker RPC now and seem to pass. I had to work around the unusual setup of the data fetcher which requires the existence of of a sleep environment variable even though that variable is not needed for fetching blockchain data.

To check that the change actually changes behavior, you can comment out the changed line locally and then run the test via `pytest tests/e2e/test_blockchain_data.py`. It should fail without the change and pass with the change.