### PR TITLE
Add database setup

### DIFF
--- a/Dockerfile.test_db
+++ b/Dockerfile.test_db
@@ -1,4 +1,4 @@
 FROM postgres
-ENV POSTGRES_PASSWORD postgres
-ENV POSTGRES_DB mainnet
+ENV POSTGRES_PASSWORD=postgres
+ENV POSTGRES_DB=mainnet
 COPY ./database/01_table_creation.sql /docker-entrypoint-initdb.d/

--- a/Dockerfile.test_db
+++ b/Dockerfile.test_db
@@ -1,0 +1,4 @@
+FROM postgres
+ENV POSTGRES_PASSWORD postgres
+ENV POSTGRES_DB mainnet
+COPY ./database/01_table_creation.sql /docker-entrypoint-initdb.d/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+DOCKER_IMAGE_NAME=test_db_image
+DOCKER_CONTAINER_NAME=test_db_container
+DB_PORT=5432
+
+install:
+	pip install -r requirements.txt
+
+imbalances:
+	python -m src.imbalances_script
+
+daemon:
+	python -m src.daemon
+
+test_db:
+	docker build -t $(DOCKER_IMAGE_NAME) -f Dockerfile.test_db .
+	docker run -d --name $(DOCKER_CONTAINER_NAME) -p $(DB_PORT):$(DB_PORT) $(DOCKER_IMAGE_NAME)
+
+stop_test_db:
+	docker stop $(DOCKER_CONTAINER_NAME) || true
+	docker rm $(DOCKER_CONTAINER_NAME) || true
+	docker rmi $(DOCKER_IMAGE_NAME) || true
+
+.PHONY: install imbalances daemon test_db run_test_db stop_test_db clean

--- a/README.md
+++ b/README.md
@@ -24,5 +24,10 @@ python -m src.imbalances_script
 python -m src.daemon
 ```
 
-**To run the basic test in the `tests/` folder:**
- using pytest, simply run the command: `pytest` 
+## Tests
+
+To build and start a local database for testing use the command
+```sh
+docker build -t test_db_image -f Dockerfile.test_db .
+docker run -d --name test_db_container -p 5432:5432 test_db_image
+```

--- a/database/01_table_creation.sql
+++ b/database/01_table_creation.sql
@@ -1,0 +1,23 @@
+CREATE TABLE token_info (
+    token_address bytea PRIMARY KEY,
+    symbol varchar NOT NULL,
+    decimals int NOT NULL
+);
+
+CREATE TABLE token_times (
+    time timestamp NOT NULL,
+    token_address bytea NOT NULL,
+    block_number bigint NOT NULL,
+    tx_hash bytea NOT NULL,
+
+    PRIMARY KEY (time, token_address, tx_hash)
+);
+
+CREATE TABLE prices (
+    time timestamp NOT NULL,
+    token_address bytea NOT NULL,
+    price numeric(60, 18) NOT NULL,
+    source varchar NOT NULL,
+
+    PRIMARY KEY (time, token_address, source)
+);

--- a/database/01_table_creation.sql
+++ b/database/01_table_creation.sql
@@ -1,23 +1,27 @@
-CREATE TABLE token_info (
-    token_address bytea PRIMARY KEY,
-    symbol varchar NOT NULL,
-    decimals int NOT NULL
+CREATE TABLE transaction_times (
+    tx_hash bytea PRIMARY KEY,
+    time timestamp NOT NULL
 );
 
-CREATE TABLE token_times (
-    time timestamp NOT NULL,
-    token_address bytea NOT NULL,
-    block_number bigint NOT NULL,
+CREATE TABLE transaction_tokens (
     tx_hash bytea NOT NULL,
+    token_address bytea NOT NULL,
 
-    PRIMARY KEY (time, token_address, tx_hash)
+    PRIMARY KEY (tx_hash, token_address)
 );
+
+CREATE TYPE PriceSource AS ENUM ('coingecko', 'moralis', 'dune', 'native');
 
 CREATE TABLE prices (
-    time timestamp NOT NULL,
     token_address bytea NOT NULL,
+    time timestamp NOT NULL,
     price numeric(60, 18) NOT NULL,
-    source varchar NOT NULL,
+    source PriceSource NOT NULL,
 
-    PRIMARY KEY (time, token_address, source)
+    PRIMARY KEY (token_address, time, source)
+);
+
+CREATE TABLE token_decimals (
+    token_address bytea PRIMARY KEY,
+    decimals int NOT NULL
 );

--- a/database/01_table_creation.sql
+++ b/database/01_table_creation.sql
@@ -1,4 +1,4 @@
-CREATE TABLE transaction_times (
+CREATE TABLE transaction_timestamps (
     tx_hash bytea PRIMARY KEY,
     time timestamp NOT NULL
 );


### PR DESCRIPTION
This PR adds a setup file for the database and a docker image to create a local database.

The database is set up to have four tables
- A table with settlement transaction hashes and timestamps.
- A table with settlement transaction hashes and token addresses. It should be populated with all tokens traded in a settlement. Together with the first table we have all tokens traded with times when they were traded.
- A table for prices from different sources.

This table structure will be mirrored once per chain.

The database can be set up locally using the commands in the README or using the make file command `make test_db`.

The code does not use this table layout yet. I am planning to add another PR which uses those tables instead of the current tables `raw_token_imbalances`, `slippage_prices`, and `fees_new`.
