### PR TITLE
Small fixes and cleanup

### DIFF
--- a/src/helpers/database.py
+++ b/src/helpers/database.py
@@ -173,11 +173,17 @@ class Database:
         )
         for token_address, time, price, source in prices:
             try:
+                date_time = datetime.fromtimestamp(time, tz=timezone.utc)
+                check_existence_query = f"SELECT * FROM prices WHERE token_address = '\\{token_address[1:]}' and time = '{date_time}' and source = '{source}'"
+                result = self.execute_query(check_existence_query, {}).fetchone()
+                if result is not None:
+                    continue
+
                 self.execute_and_commit(
                     query,
                     {
                         "token_address": bytes.fromhex(token_address[2:]),
-                        "time": datetime.fromtimestamp(time, tz=timezone.utc),
+                        "time": date_time,
                         "price": price,
                         "source": source,
                     },

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -119,9 +119,7 @@ class TransactionProcessor:
         self.log_message = []
         try:
             # compute raw token imbalances
-            token_imbalances = self.process_token_imbalances(
-                tx_hash, auction_id, block_number
-            )
+            token_imbalances = self.process_token_imbalances(tx_hash)
 
             # get transaction timestamp
             transaction_timestamp = self.blockchain_data.get_transaction_timestamp(
@@ -134,9 +132,8 @@ class TransactionProcessor:
             # transaction_tokens = self.blockchain_data.get_transaction_tokens(tx_hash)
             # store transaction tokens
             transaction_tokens = []
-            for token_address, imbalance in token_imbalances.items():
-                if imbalance != 0:
-                    transaction_tokens.append((tx_hash, token_address))
+            for token_address in token_imbalances.keys():
+                transaction_tokens.append((tx_hash, token_address))
             self.db.write_transaction_tokens(transaction_tokens)
 
             # update token decimals
@@ -202,7 +199,8 @@ class TransactionProcessor:
             return
 
     def process_token_imbalances(
-        self, tx_hash: str, auction_id: int, block_number: int
+        self,
+        tx_hash: str,
     ) -> dict[str, int]:
         """Process token imbalances for a given transaction and return imbalances."""
         try:


### PR DESCRIPTION
This PR addresses the following issues:
- Currently, we only fetch prices for tokens for which there is a non-zero imbalance. Due to network/protocol fees being implicit here, this is not enough as we might end up with slippage on tokens whose raw token imbalance is zero. With this PR, we fetch price for all tokens for which there was a transfer to or from the settlement contract.

- When multiple txs happen at the same block, the write_prices function that writes price entries in the database sometimes attempts to write a row that already exists in the db (e..g, when WETH is traded in both txs). This PR proposes to first check if the entry exists, and only proceed with writing if the entry is non-existent in the db.