### PR TITLE
Switch error to info until proper restructuring is done

### DIFF
--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -381,7 +381,7 @@ class TransactionProcessor:
                 )
                 self.log_message.append(f"Token: {token_address}, Price: {price} ETH")
         except Exception as err:
-            logger.error(f"Error: {err}")
+            logger.info(f"Error: {err}")
 
 
 def calculate_slippage(


### PR DESCRIPTION
We are spammed with errors about duplicate entries when writing prices in the prices table. this PR silences these errors.

