### PR TITLE
Fix error with writing prices to database

### DIFF
--- a/src/helpers/database.py
+++ b/src/helpers/database.py
@@ -206,7 +206,14 @@ class Database:
                                 .where(prices_table.c.source == source)
                                 .values(price=price)
                             )
-                            conn.execute(update_stmt)
+                            res = conn.execute(update_stmt)
+                            if res.rowcount == 0:
+                                logger.error(
+                                    f"Update failed, no matching record found. token: "
+                                    f"{token_address}, time: {time}, price: {price},"
+                                    f"source: {source}\n"
+                                    "This indicates a faulty database state."
+                                )
 
                         except psycopg.errors.NumericValueOutOfRange:
                             logger.info(

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -75,13 +75,21 @@ def tests_write_prices():
     token_prices = [
         (
             "0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
-            int(datetime.fromisoformat("2024-10-10 16:48:47.000000").timestamp()),
+            int(
+                datetime.fromisoformat("2024-10-10 16:48:47.000000")
+                .replace(tzinfo=timezone.utc)
+                .timestamp()
+            ),
             0.000420454193230350,
             "coingecko",
         ),
         (
             "0x68BBED6A47194EFF1CF514B50EA91895597FC91E",
-            int(datetime.fromisoformat("2024-10-10 16:49:47.000000").timestamp()),
+            int(
+                datetime.fromisoformat("2024-10-10 16:49:47.000000")
+                .replace(tzinfo=timezone.utc)
+                .timestamp()
+            ),
             0.000000050569218629,
             "moralis",
         ),
@@ -99,7 +107,7 @@ def tests_write_prices():
         ).all()
     for i, (token_address, time, price, source) in enumerate(token_prices):
         assert HexBytes(res[i][0]) == HexBytes(token_address)
-        assert res[i][1].timestamp() == time
+        assert res[i][1].replace(tzinfo=timezone.utc).timestamp() == time
         assert float(res[i][2]) == price
         assert res[i][3] == source
 


### PR DESCRIPTION
This PR attempts to fix an issue with writing prices to the database. It _might_ close #82.

Before, it could happen that the same price (i.e. the same token, time stamp, source) was inserted into the prices table. This failed due to violating the primary key constraint. This error (and potentially more?) was silenced in #84.

With this PR, the code first trys to update a value and then inserts it when the update did not succeed.

Alternatively, one could also first try to insert and update if that throws an error.

I added a test for writing a price twice. I was not able to reproduce the error by running the daemon, so that we might need to test some other way.