### PR TITLE
chore(ci): harden

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,22 +13,24 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}
           labels: |
             org.opencontainers.image.licenses=MIT OR Apache-2.0
       - name: Push Project Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: Dockerfile
@@ -36,7 +38,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - uses: cowprotocol/autodeploy-action@v2
+      - uses: cowprotocol/autodeploy-action@0c950eb2856af4f520a652b59e786bd349516480 # v2
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/token-imbalances:main

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,16 +21,18 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Initialize database
         run: |
-          for file in ${{ github.workspace }}/database/*.sql; do
+          for file in $GITHUB_WORKSPACE/database/*.sql; do
             psql -h localhost -U postgres -d mainnet -f "$file"
           done
         env:
           PGPASSWORD: postgres
       - name: Setup Python 3.12
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
       - name: Install Requirements


### PR DESCRIPTION
This PR hardens the CI by explicitly pinning all GitHub actions to their exact commit SHAs. Additionally, it enables GitHub Actions Dependabot for future upgrades + security alerts.